### PR TITLE
Fix bibliography; footcite; creation

### DIFF
--- a/authoryear-fhdw.cbx
+++ b/authoryear-fhdw.cbx
@@ -17,11 +17,11 @@
        {\printnames{labelname}%
         \setunit{\nameyeardelim}}%
      \usebibmacro{cite:labelyear+extrayear}}
-    {\usebibmacro{cite:shorthand}}}
-
+   {\usebibmacro{cite:shorthand}}}
+   
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\DeclareNameAlias{author}{sortname}
+\DeclareNameAlias{author}{last-first}
 
 \renewbibmacro*{author}{%
   \ifboolexpr{
@@ -151,7 +151,8 @@
 \DeclareCiteCommand{\footcite}[\mkbibfootnote]
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}%
-   \usebibmacro{cite}}
+   \usebibmacro{cite2}
+   }
   {\multicitedelim}
   {\usebibmacro{postnote}}
 

--- a/chapter/Grundlagen.tex
+++ b/chapter/Grundlagen.tex
@@ -90,6 +90,7 @@ Rank & PIN & Percentage & Accumulated \\
 \subsection{Zitate}
 
 Ein Zitat im Fließtext ist zu sehen bei \citet{Fuller2011}.
+Das gleiche Zitat in der Fußnote.\footcite{Fuller2011}
 
 Ein vergleichendes Zitat.\footnote{\cite[vgl.][5\psqq]{Maslennikov2011}}
 

--- a/config/Config.tex
+++ b/config/Config.tex
@@ -214,7 +214,8 @@ final             % draft beschleunigt die Kompilierung
 \usepackage[pdfpagemode={UseOutlines}, plainpages=false,breaklinks=true,pdfpagelabels]{hyperref}
 
  % Abkürzungsverzeichnis
-\usepackage[acronym,         % create list of acronyms
+\usepackage[automake,
+			acronym,         % create list of acronyms
             nonumberlist,
             toc, 
             section,
@@ -231,5 +232,5 @@ final             % draft beschleunigt die Kompilierung
 % Verbessert das Referenzieren von Kapiteln, Abbildungen etc.
 \usepackage[german,capitalise]{cleveref}
 
-\input{config/Abkuerzungen}
 \makeglossaries\makeglossaries 
+\input{config/Abkuerzungen}


### PR DESCRIPTION
This PR will fix the bibliography author naming.
In the current version the following reference will not commit to the FHDW guidelines.
![Bildschirmfoto 2022-01-21 um 11 20 05](https://user-images.githubusercontent.com/10948071/150510332-d75297a0-874b-47b8-aa15-b83346d56782.png)

This PR will render the bibliography entry as following:
![image](https://user-images.githubusercontent.com/10948071/150510813-96d990db-dae6-4a86-8b9a-79e94576b6b7.png)

Also the latex command `\footcite` will now be displayed correctly, which will make it easier to create a citation.
