### PR TITLE
Fix makes glosseries compilation Error

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,7 +25,7 @@
             "name": "makeglossaries",
             "command": "makeglossaries",
             "args": [
-                "%DOC%"
+                "%DOCFILE%"
             ],
             "env": {}
         },


### PR DESCRIPTION
In dem Template war ein Fehler innerhalb des settings.json, sofern /gls{} genutzt wurde und auf ein newacronym verwiesen wurde. Wurde ein Fehler bei der Compilierung verursacht. Der fehler wurde behoben, indem das settings.json file angepasst wurde.

- %DOC% -> Dateiname mit Exstention
- %DOCFILE% -> Ohne Exstension

Bei makeflossaries wird der Dateiname ohne die Exstension erwartet.