### PR TITLE
fixed biblatex compiler warnings

### DIFF
--- a/authoryear-fhdw.cbx
+++ b/authoryear-fhdw.cbx
@@ -16,12 +16,12 @@
         \setunit{\addspace}}
        {\printnames{labelname}%
         \setunit{\nameyeardelim}}%
-     \usebibmacro{cite:labelyear+extrayear}}
+     \usebibmacro{cite:labelyear+extradate}}
    {\usebibmacro{cite:shorthand}}}
    
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\DeclareNameAlias{author}{last-first}
+\DeclareNameAlias{author}{family-given}
 
 \renewbibmacro*{author}{%
   \ifboolexpr{
@@ -43,7 +43,7 @@
     {\global\undef\bbx@lasthash
      \usebibmacro{labeltitle}%
      \setunit*{\addspace}}%
-  \usebibmacro{date+extrayear}}
+  \usebibmacro{date+extradate}}
 
 \newbibmacro*{cite2}{%
   \iffieldundef{shorthand}
@@ -52,16 +52,16 @@
         \setunit{\addspace}}
        {\printnames{author}%
           \setunit{\addspace}}%
-     \usebibmacro{cite:labelyear+extrayear2}}
+     \usebibmacro{cite:labelyear+extradate2}}
     {\usebibmacro{cite:shorthand}}}
 
 
-\newbibmacro*{cite:labelyear+extrayear2}{%
+\newbibmacro*{cite:labelyear+extradate2}{%
   \iffieldundef{labelyear}
     {}
     {\printtext[bibhyperref]{%
        (\printfield{labelyear}%
-       \printfield{extrayear})}}}
+       \printfield{extradate})}}}
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -70,7 +70,7 @@
   \iffieldundef{shorthand}
     {\iffieldundef{labelyear}
        {\usebibmacro{cite:label}}
-       {\usebibmacro{cite:labelyear+extrayear}}}
+       {\usebibmacro{cite:labelyear+extradate}}}
     {\usebibmacro{cite:shorthand}}}
 
 \newbibmacro*{textcite}{%
@@ -83,7 +83,7 @@
         \ifnumequal{\value{citecount}}{1}
           {\usebibmacro{prenote}}
           {}%
-        \usebibmacro{cite:labelyear+extrayear}}
+        \usebibmacro{cite:labelyear+extradate}}
        {\usebibmacro{cite:shorthand}}}
     {\printnames{labelname}%
      \setunit{%
@@ -102,12 +102,12 @@
     {\printtext[bibhyperref]{\printfield[citetitle]{labeltitle}}}
     {\printtext[bibhyperref]{\printfield{label}}}}
 
-\newbibmacro*{cite:labelyear+extrayear}{%
+\newbibmacro*{cite:labelyear+extradate}{%
   \iffieldundef{labelyear}
     {}
     {\printtext[bibhyperref]{%
        \printfield{labelyear}%
-       \printfield{extrayear}}}}
+       \printfield{extradate}}}}
 
 \newbibmacro*{textcite:postnote}{%
   \iffieldundef{postnote}


### PR DESCRIPTION
author "last-first" and "date+extrayear" are deprecated
The new ones are "family-given" and "date+extradate"
The output is exactly the same but less deprecation warnings